### PR TITLE
Add a function to optimize a bvh via node reinsertion

### DIFF
--- a/documentation.lisp
+++ b/documentation.lisp
@@ -12,3 +12,11 @@
 
 This is useful to set to NIL when within a text input field, to avoid
 key bindings interfering with text input."))
+
+(in-package #:org.shirakumo.fraf.trial.bvh2)
+
+(docs:define-docs
+  (function bvh-reinsert-all
+   "Reinsert each node in BVH to its optimal position in the
+tree. Results may improve with multiple passes, the number of which
+may be specified by ROUNDS."))

--- a/package.lisp
+++ b/package.lisp
@@ -1052,6 +1052,23 @@
   ;; workbench.lisp
   (:export))
 
+(defpackage #:org.shirakumo.fraf.trial.bvh2
+  (:use #:cl #:3d-vectors)
+  (:import-from #:org.shirakumo.fraf.trial #:location #:bsize)
+  (:export
+   #:bvh
+   #:make-bvh
+   #:bvh-insert
+   #:bvh-remove
+   #:bvh-update
+   #:bvh-check
+   #:bvh-print
+   #:bvh-lines
+   #:bvh-reinsert-all
+   #:call-with-contained
+   #:call-with-overlapping
+   #:do-fitting))
+
 (defpackage #:cl+trial
   (:nicknames #:org.shirakumo.fraf.trial.cl+trial)
   (:shadowing-import-from #:trial #:// #:scene #:entity #:container #:load #:update #:particle #:oriented-entity #:sized-entity)


### PR DESCRIPTION
This commit implements a bvh optimization algorithm based on node reinsertion. Currently the only interface to this functionality is BVH-REINSERT-ALL, which scans over each node in a bvh, reinserting each one to the position in the tree which maximizes the total decrease in node perimiter. The optional parameter ROUNDS may be provided to perform this process multiple times, which improves bvh quality.

The bvh generated by a fresh new game of Kandria seems to stabilize around 50 passes or so, which take roughly one third of a second to complete on my CPU, though significant gains can be had with only a few passes, as shown in the informal benchmarks in the lichat.

As far as future work goes, we're lucky that the slow part of the algorithm, finding optimal reinsertion positions, is also the most easily parallelizable, and could also be made to run incrementally and in parallel with collision detection or frustum culling, assuming that the bvh is not mutated during the process.