### PR TITLE
Check if executable exists before sha3-ing it

### DIFF
--- a/toolkit.lisp
+++ b/toolkit.lisp
@@ -52,7 +52,7 @@
 
 (defmethod version ((_ (eql :binary)))
   (let ((self (self)))
-    (if self
+    (if (uiop:file-exists-p self)
         (with-output-to-string (out)
           (loop for o across (sha3:sha3-digest-file self :output-bit-length 224)
                 do (format out "~2,'0X" o)))


### PR DESCRIPTION
When run with e.g. `sbcl --load ./setup.lisp`, `(first (uiop:raw-command-line-arguments))` is just `"sbcl"`. The code currently attempts to open that filename in the current directory, and crashes when that doesn't exist. So, test for it first.

You could also go to more effort to try and track down the current executable, but I don't know how worthwhile that is.