### PR TITLE
Account for observed functions that yield multiple values

### DIFF
--- a/controller.lisp
+++ b/controller.lisp
@@ -141,7 +141,7 @@
                 for i from 0 below (length observers)
                 for (title . func) = (aref observers i)
                 when func
-                do (restart-case (format stream "~%~a:~12t~a" title (funcall func ev))
+                do (restart-case (format stream "~%~a:~12t~{~a~^, ~}" title (multiple-value-list (funcall func ev)))
                      (remove-observer ()
                        :report "Remove the offending observer."
                        (setf (aref observers i) NIL))))))


### PR DESCRIPTION
Previously, any other values but the first would be ignored. 

For example, a function returning an XY point via `values` would now display as `1, 2` in the observer output.